### PR TITLE
removed references to $item in carousel.js to resolve reference error

### DIFF
--- a/carousel.js
+++ b/carousel.js
@@ -13,16 +13,16 @@ $('.carousel-indicators li').each(function(){
   var $slideValue = $(this).attr('data-slide-to');
   if($currentSlide == $slideValue) {
     $(this).addClass('active');
-    $item.eq($slideValue).addClass('active');
+   
   } else {
     $(this).removeClass('active');
-    $item.eq($slideValue).removeClass('active');
+    
   }
 });
 
 $(window).on('resize', function (){
   $wHeight = $(window).height();
-  $item.height($wHeight);
+ 
 });
-$item.eq(0).addClass('active');
+
 });


### PR DESCRIPTION
removed all references to variable $item in carousel.js because it was throwing a reference error.  variable was never declared and carousel functions fine without it.  